### PR TITLE
Changing some OpenGL member variables from public to private.

### DIFF
--- a/src/engine/video/gl/gl_particle_system.h
+++ b/src/engine/video/gl/gl_particle_system.h
@@ -37,14 +37,6 @@ public:
               float* vertex_colors,
               unsigned number_of_vertices);
 
-    unsigned _number_of_indices;
-
-    GLuint _vao;
-    GLuint _vertex_position_buffer;
-    GLuint _vertex_texture_coordinate_buffer;
-    GLuint _vertex_color_buffer;
-    GLuint _index_buffer;
-
 private:
     //
     // The copy constructor and assignment operator are hidden by design
@@ -53,6 +45,14 @@ private:
 
     ParticleSystem(const ParticleSystem& particle_system);
     ParticleSystem& operator=(const ParticleSystem& particle_system);
+
+    unsigned _number_of_indices;
+
+    GLuint _vao;
+    GLuint _vertex_position_buffer;
+    GLuint _vertex_texture_coordinate_buffer;
+    GLuint _vertex_color_buffer;
+    GLuint _index_buffer;
 };
 
 } // namespace gl

--- a/src/engine/video/gl/gl_sprite.h
+++ b/src/engine/video/gl/gl_sprite.h
@@ -36,12 +36,6 @@ public:
               float* vertex_texture_coordinates,
               float* vertex_colors);
 
-    GLuint _vao;
-    GLuint _vertex_position_buffer;
-    GLuint _vertex_texture_coordinate_buffer;
-    GLuint _vertex_color_buffer;
-    GLuint _index_buffer;
-
 private:
     //
     // The copy constructor and assignment operator are hidden by design
@@ -50,6 +44,12 @@ private:
 
     Sprite(const Sprite& sprite);
     Sprite& operator=(const Sprite& sprite);
+
+    GLuint _vao;
+    GLuint _vertex_position_buffer;
+    GLuint _vertex_texture_coordinate_buffer;
+    GLuint _vertex_color_buffer;
+    GLuint _index_buffer;
 };
 
 } // namespace gl


### PR DESCRIPTION
Hi,

This is a small change.  These variables probably should have been marked as 'private' originally.  I just didn't notice they were not until now.

Let me know if there are any questions or problems.

Thanks.