### PR TITLE
Fixing a minor bug with the UI.

### DIFF
--- a/src/common/options_handler.cpp
+++ b/src/common/options_handler.cpp
@@ -1242,8 +1242,9 @@ void GameOptionsMenuHandler::_ReloadGUIDefaultSkin()
 
     _active_menu = &_video_options_menu;
 
-    // Currently, the GUI default skin option is 3.
-    _video_options_menu.SetSelection(3);
+    // Currently, the GUI default skin option is 4.
+    _video_options_menu.SetSelection(4);
+
     _RefreshVideoOptions();
 
     // Reload the explanation and change key windows.


### PR DESCRIPTION
Hi,

This is a minor bug fix.  When changing the default UI skin, the menu would incorrectly reset the cursor to the wrong location.  This change fixes it.

As a long term solution, however, we should probably make an enumeration for menu item locations and use the enumeration in place of the constant numbers.  So, when adding a new menu item, the programmer would insert a new element in the enumeration and automatically keep all the menu code "in-sync" with the menu elements.  The inverse would also hold true if a menu item would need to be removed.

On the other hand, maybe it doesn't really matter too much.  I guess this part of the code is kind of an exception because swapping the UI theme involves tearing the UI object down and building it back up to reflect the theme change.  This seems like a very unique use case.

Anyways, let me know what you think.

Have a good one.