### PR TITLE
give explanations when SDL_CreateWindow fails

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -470,8 +470,11 @@ int main(int argc, char *argv[])
                          SDL_WINDOWPOS_CENTERED,
                          800, 600, // default size
                          SDL_WINDOW_OPENGL);
-    if (!sdl_window)
+    if (!sdl_window) {
+        //be careful: I had an error saying that OpenGL context was already created. This was obviously not the truth, so do not blindly trust SDL_GetError.
+        PRINT_ERROR << "SDL window creation failed: " << SDL_GetError() << std::endl;
         return false;
+    }
 
     // Set the window icon
     SDL_Surface* icon = IMG_Load("data/icons/program_icon.png");


### PR DESCRIPTION
Title is probably explicit enough. Just add PRINT_ERROR with the info SDL_GetError() gives after the check.

I have added a comment in the code, because the error I had was that there was already an OpenGL context, which is obviously wrong.
Installing NVidia drivers, or libgl1-mesa-dri fixed this problem. I still have a crash later anyway, but I think it is because of very old hardware: installing the software rasterizer makes things working. I will check if it is not too slow to be playable hehehe (for the info, the crash occur on line 96 in gl_sprite.cpp, I wonder if there is some way to detect it... even if it is not very useful, nobody have hardware that old!).