### PR TITLE
Fixing a Map Mode Resolution Bug

### DIFF
--- a/src/engine/video/video.cpp
+++ b/src/engine/video/video.cpp
@@ -626,8 +626,9 @@ void VideoEngine::SetCoordSys(const CoordSys &coordinate_system)
 
 void VideoEngine::GetCurrentViewport(float &x, float &y, float &width, float &height)
 {
-    static GLint viewport_dimensions[4] = {(GLint)0};
+    static GLint viewport_dimensions[4] = { 0, 0, 0, 0 };
     glGetIntegerv(GL_VIEWPORT, viewport_dimensions);
+
     x = (float) viewport_dimensions[0];
     y = (float) viewport_dimensions[1];
     width = (float) viewport_dimensions[2];

--- a/src/modes/map/map_minimap.cpp
+++ b/src/modes/map/map_minimap.cpp
@@ -86,7 +86,7 @@ const SDLSurfaceController white_noise("data/gui/map/minimap_collision.png");
 //! \brief A helper function to prepare a SDL_Surface.
 static bool _PrepareSurface(SDL_Surface* temp_surface)
 {
-    SDL_Rect r = { 0 };
+    SDL_Rect r = { 0, 0, 0, 0 };
 
     // Prepare the surface with the image.  Tile the white noise image onto the surface with full alpha.
     for(int x = 0; x < temp_surface->w; x += white_noise._surface->w) {

--- a/src/modes/map/map_minimap.h
+++ b/src/modes/map/map_minimap.h
@@ -22,11 +22,11 @@
 
 #include "engine/video/image.h"
 
-//forward declerations
+// Forward declerations.
 namespace vt_gui
 {
     class MenuWindow;
-}
+} // vt_gui
 
 namespace vt_map
 {
@@ -65,13 +65,13 @@ private:
     //! \brief the generated collision map image for this collision map
     vt_video::StillImage _minimap_image;
 
-    //! \brief creates the procedural collision minimap image
-    vt_video::StillImage _CreateProcedurally();
-
     //! \brief objects for the "window" which will hold the map
     //! \note we plan to move this to a Controller object, or something similar
     //! that is a single instance held by the map itself
     vt_video::StillImage _background;
+
+    //! \brief the location sprite
+    vt_video::AnimatedImage _location_marker;
 
     //! \brief the current map locations
     float _current_position_x;
@@ -80,21 +80,6 @@ private:
     //! \brief the current box length for this collision map
     uint32 _box_x_length;
     uint32 _box_y_length;
-
-    //! \brief the location sprite
-    vt_video::AnimatedImage _location_marker;
-
-    //! \brief the original viewport information
-    float _viewport_original_x;
-    float _viewport_original_y;
-    float _viewport_original_width;
-    float _viewport_original_height;
-
-    //! \brief modified viewport information
-    float _viewport_x;
-    float _viewport_y;
-    float _viewport_width;
-    float _viewport_height;
 
     //! \brief map offset information
     float _x_offset, _y_offset;
@@ -106,19 +91,23 @@ private:
     uint32 _grid_height;
 
     //! \brief opacities for when the character is under the map location
-    const vt_video::Color *_current_opacity;
+    const vt_video::Color* _current_opacity;
 
     //! \brief specifies the additive alpha we get from the map class
     float _map_alpha_scale;
+
+    //! \brief creates the procedural collision minimap image
+    vt_video::StillImage _CreateProcedurally();
 
 #ifdef DEBUG_FEATURES
     //! \brief Writes a XPM file with the minimap equivalient in it.
     //! It is used to easily have a base to create nicer minimaps.
     void _DEV_CreateXPMFromCollisionMap(const std::string& output_file);
 #endif
-
 };
 
-}
-}
+} // private_map
+
+} // vt_map
+
 #endif // __MAP_MINIMAP_HEADER__

--- a/src/modes/map/map_mode.cpp
+++ b/src/modes/map/map_mode.cpp
@@ -95,7 +95,7 @@ MapMode::MapMode(const std::string& data_filename, const std::string& script_fil
     ResetState();
     PushState(STATE_EXPLORE);
 
-    // Load miscellaneous map graphics
+    // Load the miscellaneous map graphics.
     _dialogue_icon.LoadFromAnimationScript("data/entities/emotes/dialogue_icon.lua");
     ScaleToMapZoomRatio(_dialogue_icon);
 
@@ -165,8 +165,6 @@ MapMode::MapMode(const std::string& data_filename, const std::string& script_fil
     //! Init the camera position text style
     _debug_camera_position.SetStyle(TextStyle("title22", Color::white, VIDEO_TEXT_SHADOW_DARK));
 }
-
-
 
 MapMode::~MapMode()
 {
@@ -366,7 +364,7 @@ void MapMode::Update()
     std::ostringstream coord_txt;
     coord_txt << "Camera position: " << x_pos << ", " << y_pos;
     _debug_camera_position.SetText(coord_txt.str());
-} // void MapMode::Update()
+}
 
 void MapMode::Draw()
 {
@@ -906,13 +904,11 @@ void MapMode::_UpdateMapFrame()
     uint16 current_x = GetFloatInteger(camera_x);
     uint16 current_y = GetFloatInteger(camera_y);
 
-    // NOTE: Would the map mode coordinate system be able to dynamically change, allow this to be recomputed,
-    // and used as the multiple of the current camera tile offset.
-    if (_pixel_length_x <= 0.0f || _pixel_length_y <= 0.0f) {
-        VideoManager->GetPixelSize(_pixel_length_x, _pixel_length_y);
-        _pixel_length_x /= GRID_LENGTH;
-        _pixel_length_y /= GRID_LENGTH;
-    }
+    // Update the pixel length.
+    VideoManager->GetPixelSize(_pixel_length_x, _pixel_length_y);
+    _pixel_length_x /= GRID_LENGTH;
+    _pixel_length_y /= GRID_LENGTH;
+
     //std::cout << "the ratio is: " << _pixel_length_x << ", " << _pixel_length_y << " for resolution: "
     //<< VideoManager->GetScreenWidth() << " x " << VideoManager->GetScreenHeight() << std::endl;
 

--- a/src/modes/map/map_tiles.cpp
+++ b/src/modes/map/map_tiles.cpp
@@ -32,10 +32,21 @@ namespace vt_map
 namespace private_map
 {
 
+//! \brief A helper function to convert a string to a layer type.
+static LAYER_TYPE StringToLayerType(const std::string& type)
+{
+    if(type == "ground")
+        return GROUND_LAYER;
+    else if(type == "sky")
+        return SKY_LAYER;
+    return INVALID_LAYER;
+}
+
 TileSupervisor::TileSupervisor() :
     _num_tile_on_x_axis(0),
     _num_tile_on_y_axis(0)
-{}
+{
+}
 
 TileSupervisor::~TileSupervisor()
 {
@@ -48,16 +59,6 @@ TileSupervisor::~TileSupervisor()
     _tile_images.clear();
     _animated_tile_images.clear();
 }
-
-static LAYER_TYPE getLayerType(const std::string &type)
-{
-    if(type == "ground")
-        return GROUND_LAYER;
-    else if(type == "sky")
-        return SKY_LAYER;
-    return INVALID_LAYER;
-}
-
 
 bool TileSupervisor::Load(ReadScriptDescriptor &map_file)
 {
@@ -135,7 +136,7 @@ bool TileSupervisor::Load(ReadScriptDescriptor &map_file)
         // Add a layer for the base context
         _tile_grid.resize(layer_id + 1);
 
-        LAYER_TYPE layer_type = getLayerType(map_file.ReadString("type"));
+        LAYER_TYPE layer_type = StringToLayerType(map_file.ReadString("type"));
 
         if(layer_type == INVALID_LAYER) {
             PRINT_WARNING << "Ignoring unexisting layer type: " << layer_type
@@ -311,9 +312,7 @@ bool TileSupervisor::Load(ReadScriptDescriptor &map_file)
     tileset_images.clear();
 
     return true;
-} // bool TileSupervisor::Load(ReadScriptDescriptor& map_file)
-
-
+}
 
 void TileSupervisor::Update()
 {
@@ -321,7 +320,6 @@ void TileSupervisor::Update()
         _animated_tile_images[i]->Update();
     }
 }
-
 
 void TileSupervisor::DrawLayers(const MapFrame *frame, const LAYER_TYPE &layer_type)
 {
@@ -355,7 +353,8 @@ void TileSupervisor::DrawLayers(const MapFrame *frame, const LAYER_TYPE &layer_t
             VideoManager->MoveRelative(-static_cast<float>(frame->num_draw_x_axis) * TILE_LENGTH, TILE_LENGTH);
         } // y
     } // layer_id
-    // Restore the previous draw flags
+
+    // Restore the previous draw flags.
     VideoManager->SetDrawFlags(VIDEO_BLEND, VIDEO_X_CENTER, VIDEO_Y_BOTTOM, 0);
 }
 


### PR DESCRIPTION
If you change the resolution while currently in Map Mode, the map will not rescale properly to support the new resolution.

This commit attempts to fix this issue.  I addressed two main problems.

First, in MapMode::_UpdateMapFrame(), the original code was assuming a fixed resolution.  It was using this assumption to only update some of its variables once.  So, the simple solution is to make it update its variables every frame.  It's not doing anything computationally intensive.  It should be fine.

The next major change occurred in the minimap object.  The minimap adjusts the viewport during rendering to only draw to the section of the screen where the minimap should be drawn.  In the original implementation, the minimap object would cache the game's resolution at its creation time.

So, if a player would change the resolution during Map Mode, the minimap object would still retain the original resolution.  During rendering, the minimap object would "restore" the viewport back to its incorrect stored viewport.  The changes should resolve this.

Let me know what you think.