### PR TITLE
Rush implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -393,6 +393,8 @@ modes/battle/battle_utils.cpp
 modes/battle/battle_utils.h
 modes/battle/battle_command.cpp
 modes/battle/battle_command.h
+modes/battle/battle_menu.cpp
+modes/battle/battle_menu.h
 modes/battle/battle.cpp
 modes/battle/battle.h
 modes/battle/battle_finish.cpp

--- a/src/modes/battle/battle.h
+++ b/src/modes/battle/battle.h
@@ -25,6 +25,7 @@
 #define __BATTLE_HEADER__
 
 #include "battle_utils.h"
+#include "battle_menu.h"
 
 #include "engine/audio/audio_descriptor.h"
 #include "engine/mode_manager.h"
@@ -609,11 +610,18 @@ private:
     //! \brief Tells whether the battle is a boss fight.
     bool _is_boss_battle;
 
+    //! \brief Whether rush was active last simtick. Cached so we can know right when it's toggled on
+    bool _rush_was_active;
+
+    //! \brief The battle menu
+    vt_battle::private_battle::BattleMenu _battle_menu;
+
     //! \brief Whether the hero party should get an initiative boost at battle start.
     bool _hero_init_boost;
 
     //! \brief Whether the enemy party should get an initiative boost at battle start.
     bool _enemy_init_boost;
+    
 
     ////////////////////////////// PRIVATE METHODS ///////////////////////////////
 
@@ -622,6 +630,11 @@ private:
 
     //! \brief Set the battle music state
     void _ResetMusicState();
+
+    /** \brief Applies a rush command to a given character
+    *** \param character The character to be rushed
+    **/
+    void _RushCharacterCommand(private_battle::BattleCharacter* character);
 
     /** \brief Sets the origin location of all character and enemy actors
     *** The location of the actors in both parties is dependent upon the number and physical size of the actor
@@ -642,6 +655,7 @@ private:
     *** \note This function only counts the characters on the screen, not characters in the party reserves
     **/
     uint32 _NumberCharactersAlive() const;
+
 
     //! \name Draw assistant functions
     //@{

--- a/src/modes/battle/battle_command.h
+++ b/src/modes/battle/battle_command.h
@@ -29,6 +29,8 @@
 #include "battle_utils.h"
 #include "battle_actors.h"
 
+#include "battle_menu.h"
+
 namespace vt_battle
 {
 
@@ -382,6 +384,14 @@ public:
     *** target, the next available valid target will be selected instead.
     **/
     void NotifyActorDeath(private_battle::BattleActor *actor);
+
+    /** \brief Cancels the current command
+    ***
+    *** This function cancels the command without checking whether the battle 
+    *** is in WAIT, SEMI-ACTIVE or ACTIVE mode. If this check is desired, it 
+    *** must be done by the caller.
+    **/
+    void CancelCurrentCommand();
 
     //! \name Class member accessor methods
     //@{

--- a/src/modes/battle/battle_menu.cpp
+++ b/src/modes/battle/battle_menu.cpp
@@ -1,0 +1,140 @@
+////////////////////////////////////////////////////////////////////////////////
+//            Copyright (C) 2004-2011 by The Allacrost Project
+//            Copyright (C) 2012-2014 by Bertram (Valyria Tear)
+//                         All Rights Reserved
+//
+// This code is licensed under the GNU GPL version 2. It is free software and
+// you may modify it and/or redistribute it under the terms of this license.
+// See http://www.gnu.org/copyleft/gpl.html for details.
+////////////////////////////////////////////////////////////////////////////////
+
+/** ****************************************************************************
+*** \file    battle_menu.cpp
+*** \author  Christopher Berman, suitecake@gmail.com
+*** \brief   Source file for battle menu
+*** ***************************************************************************/
+
+#include "utils/utils_pch.h"
+#include "engine/input.h"
+#include "modes/battle/battle_menu.h"
+
+#include "engine/video/video.h"
+
+using namespace vt_video;
+using namespace vt_gui;
+using namespace vt_system;
+using namespace vt_input;
+
+namespace vt_battle
+{
+
+namespace private_battle
+{
+
+const float WINDOW_POS_X = 512.0f;
+const float WINDOW_POS_Y = 500.0f;
+const float WINDOW_SIZE_X = 412.0f;
+const float WINDOW_SIZE_Y = 120.0f;
+
+const float OPTION_LIST_SIZE_X = WINDOW_SIZE_X;
+const float OPTION_LIST_SIZE_Y = WINDOW_SIZE_Y;
+const float OPTION_LIST_POS_X = WINDOW_POS_X + 25.0f;
+const float OPTION_LIST_POS_Y = WINDOW_POS_Y + 60.0f;
+
+const int RUSH_INDEX = 0;
+
+BattleMenu::BattleMenu()
+{
+    _window.Create(WINDOW_SIZE_X, WINDOW_SIZE_Y);
+    _window.SetPosition(WINDOW_POS_X, WINDOW_POS_Y);
+    _window.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
+    _window.Show();
+
+    _options_list.SetPosition(OPTION_LIST_POS_X, OPTION_LIST_POS_Y);
+    _options_list.SetDimensions(WINDOW_SIZE_X - 25.0f, WINDOW_SIZE_Y - 25.0f, 3, 2, 3, 2);
+    _options_list.SetTextStyle(TextStyle("title22"));
+    _options_list.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
+    _options_list.SetOptionAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
+    _options_list.SetSelectMode(VIDEO_SELECT_SINGLE);
+    _options_list.SetVerticalWrapMode(VIDEO_WRAP_MODE_STRAIGHT);
+    _options_list.SetCursorOffset(-82.0f, -28.0f);
+    _options_list.SetSkipDisabled(true);
+
+    _RefreshOptions();
+}
+
+BattleMenu::~BattleMenu()
+{
+    _window.Destroy();
+}
+
+void BattleMenu::Draw()
+{
+    assert(_open);
+
+    _window.Draw();
+    _options_list.Draw();
+}
+
+void BattleMenu::Update()
+{
+    if (_open == false)
+        return;
+
+    if(InputManager->CancelPress()) {
+        _open = false;
+        return;
+    }
+
+    if (InputManager->ConfirmPress()) {
+        if (_options_list.GetSelection() == RUSH_INDEX) {
+            _rushActive = !_rushActive;
+
+            // Automatically close menu if rush is turned on
+            if (_rushActive)
+                _open = false;
+
+            _RefreshOptions();
+        }
+    }
+}
+
+void BattleMenu::Open()
+{
+    _open = true;
+}
+
+void BattleMenu::Close()
+{
+    _open = false;
+}
+
+bool BattleMenu::IsRushActive() const
+{
+    return _rushActive;
+}
+
+bool BattleMenu::IsOpen() const
+{
+    return _open;
+}
+
+void BattleMenu::_RefreshOptions()
+{
+    _options_list.ClearOptions();
+
+    _options_list.AddOption();
+    if (_rushActive) {
+        _options_list.SetCursorOffset(-50.0f, -28.0f);
+        _options_list.AddOptionElementImage(RUSH_INDEX, "data/gui/menus/star.png");
+    }
+    else {
+        _options_list.SetCursorOffset(-82.0f, -28.0f);
+    }
+    _options_list.AddOptionElementPosition(RUSH_INDEX, 32);
+    _options_list.AddOptionElementText(RUSH_INDEX, UTranslate("Rush"));
+}
+
+} // namespace private_battle
+
+} // namespace vt_battle

--- a/src/modes/battle/battle_menu.h
+++ b/src/modes/battle/battle_menu.h
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////////
+//            Copyright (C) 2004-2011 by The Allacrost Project
+//            Copyright (C) 2012-2014 by Bertram (Valyria Tear)
+//                         All Rights Reserved
+//
+// This code is licensed under the GNU GPL version 2. It is free software and
+// you may modify it and/or redistribute it under the terms of this license.
+// See http://www.gnu.org/copyleft/gpl.html for details.
+////////////////////////////////////////////////////////////////////////////////
+
+/** ****************************************************************************
+*** \file    battle_menu.h
+*** \author  Christopher Berman, suitecake@gmail.com
+*** \brief   Header file for battle sub-menu
+***
+*** This code is responsible for both the display and logic of the main battle
+*** menu, which includes options such as Rush. This class is directly tied to
+*** the CommandSupervisor class.
+*** ***************************************************************************/
+
+#ifndef __BATTLE_MENU_HEADER__
+#define __BATTLE_MENU_HEADER__
+
+#include "common/gui/menu_window.h"
+#include "common/gui/option.h"
+
+namespace vt_battle
+{
+
+namespace private_battle
+{
+//! \brief Encapsulates the battle menu
+class BattleMenu
+{
+public:
+    //! \brief The class constructor generates the GUI
+    BattleMenu();
+
+    ~BattleMenu();
+
+    //! \brief Draws the menu
+    void Draw();
+
+    //! \brief Updates the menu state
+    void Update();
+
+    //! \brief Opens the menu
+    void Open();
+
+    //! \brief Closes the menu
+    void Close();
+
+    /** \brief Returns whether rush is active
+    *** \return Whether rush is active
+    **/
+    bool IsRushActive() const;
+
+    /** \brief Returns whether the menu is open
+    *** \return Whether the menu is open
+    **/
+    bool IsOpen() const;
+
+private:
+    //! \brief The window where all information about the currently selected action is drawn
+    vt_gui::MenuWindow _window;
+
+    //! \brief The list of menu options
+    vt_gui::OptionBox _options_list;
+
+    //! \brief Whether rush is active
+    bool _rushActive;
+
+    //! \brief Whether the menu is open
+    bool _open;
+
+    //! \brief Redraws the options
+    void _RefreshOptions();
+};
+
+} // namespace private_battle
+
+} // namespace vt_battle
+
+#endif // __BATTLE_MENU_HEADER__

--- a/vs2013/ValyriaTear/ValyriaTear.vcxproj
+++ b/vs2013/ValyriaTear/ValyriaTear.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="..\..\src\modes\battle\battle_command.cpp" />
     <ClCompile Include="..\..\src\modes\battle\battle_effects.cpp" />
     <ClCompile Include="..\..\src\modes\battle\battle_finish.cpp" />
+    <ClCompile Include="..\..\src\modes\battle\battle_menu.cpp" />
     <ClCompile Include="..\..\src\modes\battle\battle_sequence.cpp" />
     <ClCompile Include="..\..\src\modes\battle\battle_utils.cpp" />
     <ClCompile Include="..\..\src\modes\boot\boot.cpp" />
@@ -260,6 +261,7 @@
     <ClInclude Include="..\..\src\modes\battle\battle_command.h" />
     <ClInclude Include="..\..\src\modes\battle\battle_effects.h" />
     <ClInclude Include="..\..\src\modes\battle\battle_finish.h" />
+    <ClInclude Include="..\..\src\modes\battle\battle_menu.h" />
     <ClInclude Include="..\..\src\modes\battle\battle_sequence.h" />
     <ClInclude Include="..\..\src\modes\battle\battle_utils.h" />
     <ClInclude Include="..\..\src\modes\boot\boot.h" />

--- a/vs2013/ValyriaTear/ValyriaTear.vcxproj.filters
+++ b/vs2013/ValyriaTear/ValyriaTear.vcxproj.filters
@@ -191,6 +191,9 @@
     <ClCompile Include="..\..\src\modes\battle\battle_utils.cpp">
       <Filter>modes\battle</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\modes\battle\battle_menu.cpp">
+      <Filter>modes\battle</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\modes\boot\boot.cpp">
       <Filter>modes\boot</Filter>
     </ClCompile>
@@ -568,6 +571,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\modes\map\map_status_effects.h">
       <Filter>modes\map</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\modes\battle\battle_menu.h">
+      <Filter>modes\battle</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\engine\video\gl\gl_particle_system.h">
       <Filter>engine\video\gl</Filter>


### PR DESCRIPTION
Updated the rush implementation per comments on the previous PR (#473).

- Opening the battle menu no longer pauses the battle
- Removed BATTLE_STATE_MENU and refactored corresponding logic. Since opening the menu does not pause the battle, it isn't a true battle state. This simplifies things a bit.
- Refactored battle_menu
- Resized battle_menu and adjusted position (now displays above command menu, and is smaller)
- Activating Rush in the battle menu now immediately closes the menu. If a character's command menu is open when rush is activated, the command menu is canceled out and a rush command is set for the character.
- Added a public function for canceling the current command to CommandSupervisor (to facilitate the above functionality). This function is agnostic to whether the battle is in WAIT, SEMI-ACTIVE or ACTIVE modes (since the above functionality requires a means to cancel a command, regardless of what the battle type is).