### PR TITLE
Updating the Temporary Image Folder

### DIFF
--- a/src/engine/video/texture_controller.h
+++ b/src/engine/video/texture_controller.h
@@ -88,9 +88,6 @@ public:
     **/
     void DEBUG_ShowTexSheet();
 
-    //! \brief An index to _tex_sheets of the current texture sheet being shown in debug mode. -1 indicates no sheet
-    int32 debug_current_sheet;
-
 private:
     ~TextureController();
 
@@ -105,6 +102,9 @@ private:
 
     //! \brief A STL set containing all of the text images currently being managed by this class
     std::set<private_video::TextTexture *> _text_images;
+
+    //! \brief An index to _tex_sheets of the current texture sheet being shown in debug mode. -1 indicates no sheet
+    int32 _debug_current_sheet;
 
     //! \brief Keeps track of the number of texture switches per frame
     uint32 _debug_num_tex_switches;
@@ -131,19 +131,18 @@ private:
      */
     void _DeleteTexture(GLuint tex_id);
 
-    /** \brief Saves all temporary textures (textures not loaded from a file) to disk
-    *** \return True only if all temporary textures were successfully saved to a file
+    /** \brief Saves all temporary textures.
+    *** \return True only if all temporary textures were successfully saved.
     ***
-    *** This is used when the GL context is being destroyed, perhaps because we are
-    *** switching from windowed to fullscreen. We must save all textures to disk so
+    *** This is used when the GL context is being destroyed.  Perhaps because we are
+    *** switching from windowed to fullscreen.  We must save all textures to disk so
     *** that we can reload them after the new GL context is created.
     **/
     bool _SaveTempTextures();
 
-    /** \brief Deletes any temporary textures that were saved in the "img/temp" directory
-    *** \return True if the "img/temp" directory was successfully emptied
+    /** \brief Deletes any temporary textures.
+    *** \return True if successful.
     **/
-    //FIXME: Use official temp folders.
     bool _DeleteTempTextures();
     //@}
 

--- a/src/engine/video/video.cpp
+++ b/src/engine/video/video.cpp
@@ -427,7 +427,7 @@ void VideoEngine::Update()
 
 void VideoEngine::DrawDebugInfo()
 {
-    if (TextureManager->debug_current_sheet >= 0)
+    if (TextureManager->_debug_current_sheet >= 0)
         TextureManager->DEBUG_ShowTexSheet();
 
     if (_fps_display)

--- a/src/engine/video/video.cpp
+++ b/src/engine/video/video.cpp
@@ -626,7 +626,7 @@ void VideoEngine::SetCoordSys(const CoordSys &coordinate_system)
 
 void VideoEngine::GetCurrentViewport(float &x, float &y, float &width, float &height)
 {
-    static GLint viewport_dimensions[4] = { 0, 0, 0, 0 };
+    GLint viewport_dimensions[4] = { 0, 0, 0, 0 };
     glGetIntegerv(GL_VIEWPORT, viewport_dimensions);
 
     x = (float) viewport_dimensions[0];

--- a/src/modes/map/map_minimap.cpp
+++ b/src/modes/map/map_minimap.cpp
@@ -34,16 +34,16 @@ namespace private_map
 {
 
 //! \brief The default opcaity.
-const vt_video::Color default_opacity(1.0f, 1.0f, 1.0f, 0.75f);
+const vt_video::Color DEFAULT_OPACITY(1.0f, 1.0f, 1.0f, 0.75f);
 
 //! \brief The overlap opcaity.
-const vt_video::Color overlap_opacity(1.0f, 1.0f, 1.0f, 0.45f);
+const vt_video::Color OVERLAP_OPACITY(1.0f, 1.0f, 1.0f, 0.45f);
 
 //! \brief The X value for the minimap's position.
-const float minimap_pos_x = 775.0f;
+const float MINIMAP_POS_X = 775.0f;
 
 //! \brief The Y value for the minimap's position.
-const float minimap_pos_y = 545.0f;
+const float MINIMAP_POS_Y = 545.0f;
 
 //! \brief Allows for scoped-based control of SDL Surfaces.
 struct SDLSurfaceController {
@@ -53,7 +53,7 @@ struct SDLSurfaceController {
         _surface(IMG_Load(str))
     {
         if (!_surface)
-            PRINT_ERROR << "Couldn't create white_noise image for collision map: " << SDL_GetError() << std::endl;
+            PRINT_ERROR << "Couldn't create the white noise image for the collision map: " << SDL_GetError() << std::endl;
     }
 
     ~SDLSurfaceController()
@@ -81,7 +81,7 @@ private:
 };
 
 //! \brief A white noise texture.
-const SDLSurfaceController white_noise("data/gui/map/minimap_collision.png");
+const SDLSurfaceController WHITE_NOISE("data/gui/map/minimap_collision.png");
 
 //! \brief A helper function to prepare a SDL_Surface.
 static bool _PrepareSurface(SDL_Surface* temp_surface)
@@ -89,11 +89,11 @@ static bool _PrepareSurface(SDL_Surface* temp_surface)
     SDL_Rect r = { 0, 0, 0, 0 };
 
     // Prepare the surface with the image.  Tile the white noise image onto the surface with full alpha.
-    for(int x = 0; x < temp_surface->w; x += white_noise._surface->w) {
+    for(int x = 0; x < temp_surface->w; x += WHITE_NOISE._surface->w) {
         r.x = x;
-        for(int y = 0; y < temp_surface->h; y += white_noise._surface->h) {
+        for(int y = 0; y < temp_surface->h; y += WHITE_NOISE._surface->h) {
             r.y = y;
-            if(SDL_BlitSurface(white_noise._surface, nullptr, temp_surface, &r)) {
+            if(SDL_BlitSurface(WHITE_NOISE._surface, nullptr, temp_surface, &r)) {
                 PRINT_ERROR << "Couldn't fill a rect on temp_surface: " << SDL_GetError() << std::endl;
                 return false;
             }
@@ -250,7 +250,7 @@ void Minimap::Draw()
     vt_video::VideoManager->SetStandardCoordSys();
 
     // Draw the background in the current viewport and coordinate space
-    vt_video::VideoManager->Move(minimap_pos_x, minimap_pos_y);
+    vt_video::VideoManager->Move(MINIMAP_POS_X, MINIMAP_POS_Y);
     vt_video::VideoManager->SetDrawFlags(vt_video::VIDEO_X_LEFT, vt_video::VIDEO_Y_TOP, 0);
     _background.Draw(resultant_opacity);
 
@@ -318,11 +318,11 @@ void Minimap::Update(VirtualSprite *camera, float map_alpha_scale)
 
     // Update the opacity based on the camera location.
     // We decrease the opacity if it is in the region covered by the collision map
-    if(map_mode->GetScreenXCoordinate(_current_position_x) >= minimap_pos_x &&
-            map_mode->GetScreenYCoordinate(_current_position_y) >= minimap_pos_y)
-        _current_opacity = &overlap_opacity;
+    if(map_mode->GetScreenXCoordinate(_current_position_x) >= MINIMAP_POS_X &&
+            map_mode->GetScreenYCoordinate(_current_position_y) >= MINIMAP_POS_Y)
+        _current_opacity = &OVERLAP_OPACITY;
     else
-        _current_opacity = &default_opacity;
+        _current_opacity = &DEFAULT_OPACITY;
 
     // Update the orthographic projection information based on the camera location
     // We "lock" the minimap so that if it is against an edge of the map the orthographic

--- a/src/utils/utils_files.h
+++ b/src/utils/utils_files.h
@@ -24,11 +24,11 @@ namespace vt_utils
 
 //! \name Directory and File Manipulation Functions
 //@{
-/** \brief Checks if a file exists on the system or not
+/** \brief Checks if a file exists.
 *** \param file_name The name of the file to check (e.g. "saves/saved_game.lua")
 *** \return True if the file was found, or false if it was not found.
 **/
-bool DoesFileExist(const std::string &file_name);
+bool DoesFileExist(const std::string& file_name);
 
 /** \brief Moves a file from one location to another
 *** \param source_name The name of the file that is to be moved
@@ -46,19 +46,19 @@ bool MoveFile(const std::string &source_name, const std::string &destination_nam
  **/
 void CopyFile(const std::string &source, const std::string &destination);
 
-/** \brief Removes all files present in a directory
+/** \brief Removes all files in a directory.
 *** \param dir_name The name of the directory to clean (e.g. "/temp/screenshots")
 *** \return True upon success, false upon failure
 **/
 bool CleanDirectory(const std::string &dir_name);
 
-/** \brief Creates a directory relative to the path of the running application
+/** \brief Creates a directory.
 *** \param dir_name The name of the directory to create (e.g. "/temp/screenshots")
 *** \return True upon success, false upon failure
 **/
 bool MakeDirectory(const std::string &dir_name);
 
-/** \brief Deletes a directory, as well as any files the directory may contain
+/** \brief Deletes a directory and any files in the directory.
 *** \param dir_name The name of the directory to remove (e.g. "/temp/screenshots")
 *** \return True upon success, false upon failure
 **/


### PR DESCRIPTION
Hi,

This pull request begins to address the temporary image issues.  Currently, I have only updated where the temporary images are stored.  The changing resolution background image bugs still need addressed.

I wanted to post this code to get some initial feedback and to make sure everything was on the right track.

I also updated some of the file utility code.  There were two concerns with it.

First, I changed to the code to always use 'GetFileAttributesA' over 'stat' on Windows.  On Windows, 'stat' needs permissions in every directory of the path of the file to work properly.  Normally, Windows programs are installed in 'Program Files'.  The operating system restricts access to files and folders within 'Program Files' by definition.  It is basically a security feature so people can not break their computer.  So, unless a program is always run as administrator or has a non-traditional installation, it is hard for a program to use 'stat' as the function was originally intended to be used.

Second, some of the code treated parameters as relative paths, which is fine.  However, in the implementation, it would convert the relative path to an absolute path using the working directory of the game.  I have my VT installation on Drive D; my operating system is installed on Drive C.  So, the 'My Documents' and 'AppData' directories for VT are not on the same drive as the game.  This breaks the relative to absolute conversion.  (As a side note, I do not think the *nix code branch follows this same procedure.  I think it already works correctly for this case.  I did not actually test it though.)

Let me know what you think.

Finally, in regards to the actual resolution bug, I think we need to redraw each game state in the game state stack and capture new background images on a resolution change.

For example, if we have the following game state stack

C
B
A

where game state 'C' is the current game state and it depends on background images from game states 'B' and 'A'.  I think we need to pop the entire stack and start with 'A'.  Redraw 'A'.  Put 'A' back on the stack.  Then, have game state 'B' capture a new image of 'A'.  Redraw 'B'.  Put 'B' back on the stack.  Have game state 'C' capture a new image of 'B'.  Redraw 'C'.  Put 'C' back on the stack.